### PR TITLE
fix panics when API calls fail

### DIFF
--- a/collector/account.go
+++ b/collector/account.go
@@ -47,6 +47,7 @@ func (c *AccountCollector) Collect(ch chan<- prometheus.Metric) {
 	account, err := c.client.GetAccount(ctx)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 
 	ch <- prometheus.MustNewConstMetric(

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -65,6 +65,7 @@ func (c *InstanceCollector) Collect(ch chan<- prometheus.Metric) {
 	instances, err := c.client.ListInstances(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	log.Printf("[InstaneCollector:Collect] len(instances)=%d", len(instances))
 

--- a/collector/instance_stats.go
+++ b/collector/instance_stats.go
@@ -63,6 +63,7 @@ func (c *InstanceStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	instances, err := c.client.ListInstances(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	log.Printf("[InstanceStatsCollector:Collect] len(instances)=%d", len(instances))
 

--- a/collector/kubernetes.go
+++ b/collector/kubernetes.go
@@ -55,6 +55,7 @@ func (c *KubernetesCollector) Collect(ch chan<- prometheus.Metric) {
 	clusters, err := c.client.ListLKEClusters(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	log.Printf("[KubernetesCollector:Collect] len(clusters)=%d", len(clusters))
 
@@ -73,6 +74,7 @@ func (c *KubernetesCollector) Collect(ch chan<- prometheus.Metric) {
 			pools, err := c.client.ListLKEClusterPools(ctx, k.ID, nil)
 			if err != nil {
 				log.Println(err)
+				return
 			}
 			log.Printf("[KubernetesCollector:Collect] Cluster: %d len(nodepools)=%d", k.ID, len(pools))
 

--- a/collector/nodebalancer.go
+++ b/collector/nodebalancer.go
@@ -63,6 +63,7 @@ func (c *NodeBalancerCollector) Collect(ch chan<- prometheus.Metric) {
 	nodebalancers, err := c.client.ListNodeBalancers(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	log.Printf("[NodeBalancerCollector:Collect] len(nodebalancers)=%d", len(nodebalancers))
 

--- a/collector/ticket.go
+++ b/collector/ticket.go
@@ -41,6 +41,7 @@ func (c *TicketCollector) Collect(ch chan<- prometheus.Metric) {
 	tickets, err := c.client.ListTickets(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 
 	total := make(map[linodego.TicketStatus]float64)

--- a/collector/volume.go
+++ b/collector/volume.go
@@ -41,6 +41,7 @@ func (c *VolumeCollector) Collect(ch chan<- prometheus.Metric) {
 	volumes, err := c.client.ListVolumes(ctx, nil)
 	if err != nil {
 		log.Println(err)
+		return
 	}
 	log.Printf("[VolumeCollector:Collect] len(volumes)=%d", len(volumes))
 


### PR DESCRIPTION
every so often my instance will panic due to some network hiccup:
```
2024/02/22 21:22:42.704302 ERROR RESTY Get "https://api.linode.com/v4/account": read tcp 10.244.0.202:42616->88.221.221.99:443: read: connection reset by peer, Attempt 1
{"level":"info","msg":"[002] Get \"https://api.linode.com/v4/account\": read tcp 10.244.0.202:42616-\u003e88.221.221.99:443: read: connection reset by peer","time":"2024-02-22T21:22:42Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x7e5b3e]

goroutine 142 [running]:
github.com/DazWilkin/linode-exporter/collector.(*AccountCollector).Collect(0xc000234300, 0xc0001e7f60?)
	/linode-exporter/collector/account.go:57 +0xde
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:443 +0x10d
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:535 +0xb0c
```

This PR should prevent this by returning early when an API Client returns an error